### PR TITLE
fix: display monaco errors even if there is no avsc errors

### DIFF
--- a/app/components/editor/Editor.tsx
+++ b/app/components/editor/Editor.tsx
@@ -122,7 +122,7 @@ export default function Editor(props: Props) {
           </div>
         </Content>
         <ErrorFeedback
-          isInError={avro.isInError}
+          isInError={avro.isInError || errors.length > 0}
           avroError={avro.errorMessage}
           editorErrors={errors}
         />

--- a/app/components/error-feedback/ErrorFeedback.tsx
+++ b/app/components/error-feedback/ErrorFeedback.tsx
@@ -25,7 +25,7 @@ export default function ErrorFeedback(props: Props) {
     </p>
   ));
 
-  const avroErrorAlert = (
+  const avroErrorAlert = avroError && (
     <p>
       <Tag color="purple" className={classNames.tag}>
         Avro

--- a/app/reducers/editor.ts
+++ b/app/reducers/editor.ts
@@ -11,7 +11,7 @@ import {
   ChangeJsonAction
 } from '../actions/editor';
 
-interface EditorValue {
+export interface EditorValue {
   str: string;
   parsed: object | null;
   sourceMap: SourceMap | null;


### PR DESCRIPTION
This fixes the case of the following avro : 
```json
{
    "type": "record",
    "fields": [
        {
            "type": "string",
            "name": "code"
        },
        {
            "type": "string",
            "name": "code2"
        }
    ]
}
```
which was considered as valid even if it has no name